### PR TITLE
Add bearer token retrieval script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # data_engineer_study
+
+This repository contains utilities and study materials. The project now includes a Python
+script for retrieving a bearer token from an HTTP API.
+
+## Getting a bearer token
+
+1. Install the `requests` package if it's not available:
+
+```bash
+pip install requests
+```
+
+2. Set the following environment variables with your API credentials:
+
+- `API_USERNAME`: your username
+- `API_PASSWORD`: your password
+- `LOGIN_URL`: (optional) the authentication endpoint. Defaults to
+  `https://example.com/api/login`.
+
+3. Run the script:
+
+```bash
+python get_bear_token.py
+```
+
+The script will print the bearer token to standard output.
+

--- a/get_bear_token.py
+++ b/get_bear_token.py
@@ -1,0 +1,30 @@
+import os
+import requests
+
+def get_token(login_url: str, username: str, password: str) -> str:
+    """Obtain a bearer token from an HTTP API."""
+    response = requests.post(
+        login_url,
+        data={"username": username, "password": password},
+        headers={"Accept": "application/json"},
+        timeout=10,
+    )
+    response.raise_for_status()
+    data = response.json()
+    token = data.get("token") or data.get("access_token")
+    if not token:
+        raise ValueError("Token not found in response")
+    return token
+
+
+def main() -> None:
+    login_url = os.environ.get("LOGIN_URL", "https://example.com/api/login")
+    username = os.environ["API_USERNAME"]
+    password = os.environ["API_PASSWORD"]
+
+    token = get_token(login_url, username, password)
+    print(token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add sample Python script `get_bear_token.py` that retrieves a bearer token
- update README with instructions for using the script

## Testing
- `python -m py_compile get_bear_token.py`


------
https://chatgpt.com/codex/tasks/task_e_684f427ede748321a99f415f312f60d3